### PR TITLE
set C locale to get RFC822 formatted date

### DIFF
--- a/runtime/ftplugin/spec.vim
+++ b/runtime/ftplugin/spec.vim
@@ -113,7 +113,10 @@ if !exists("*s:SpecChangelog")
 			endif
 		endif
 		if (chgline != -1)
+			let tmptime = v:lc_time
+			execute "language time C"
 			let parsed_format = "* ".strftime(format)." - ".ver."-".rel
+			execute "language time " . tmptime
 			let release_info = "+ ".name."-".ver."-".rel
 			let wrong_format = 0
 			let wrong_release = 0


### PR DESCRIPTION
This fixes the dates in rpm changelog entries that are added by spec.vim.
Currently the date is based on LC_TIME and rpm allows only  RFC822 (LC_TIME=C) dates.

Reproducer:

> export LC_TIME=de_DE
> vim vim.spec
press maplocalleader key plus 'c'

* Di Apr 12 2016 username <username@example.com>
^^^
   This is not allowed by rpm.